### PR TITLE
Add js

### DIFF
--- a/canibeloud/Cargo.lock
+++ b/canibeloud/Cargo.lock
@@ -344,6 +344,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "chrono",
+ "serde",
 ]
 
 [[package]]

--- a/canibeloud/Cargo.toml
+++ b/canibeloud/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 actix-web = "4"
 chrono = "0.4.31"
+serde = { version = "1.0", features = ["derive"] }

--- a/canibeloud/src/main.rs
+++ b/canibeloud/src/main.rs
@@ -1,8 +1,24 @@
 mod rules;
+use canibeloud::can_i_be_loud::CanIBeLoud;
 use rules::rule_gr::RuleGR;
 mod canibeloud;
 
-use actix_web::{get, post, App, HttpResponse, HttpServer, Responder};
+use actix_web::{web, get, App, HttpResponse, HttpServer, Responder, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct TimezoneFromRequest {
+    timezone: String,
+}
+
+#[derive(Serialize)]
+struct CanIBeLoudResponse {
+    can_i_be_loud: bool,
+    response_text: String,
+    requested_timezone: String,
+    timezone_found: bool,
+    calculated_datetime: String,
+}
 
 #[get("/")]
 async fn hello() -> impl Responder {
@@ -12,23 +28,90 @@ async fn hello() -> impl Responder {
     // 4. print the message
     let rule = RuleGR::can_i_be_loud();
 
-    let answer = format!("
-<html>
+    let targetElementId = "content";
+    let answer = format!(r#"
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {{
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }}
+
+        #{targetElementId} {{
+            font-size: 15vw;
+            text-align: center;
+            padding: 10vw;
+            border-radius: 10px;
+        }}
+
+        .yes {{
+            background-color: green;
+            color: white;
+        }}
+
+        .no {{
+            background-color: red;
+            color: white;
+        }}
+    </style>
+    <script>
+        function can_i_be_loud() {{
+            console.log("boo");
+            let origin = window.location.origin;
+            let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            fetch(
+                `${{origin}}/cibl`,
+                {{
+                    "method": "POST",
+                    "headers": {{"Content-Type": "application/json"}},
+                    "body": JSON.stringify({{"timezone": timezone}})
+                }}
+            ).then((response) => response.json())
+            .then((data) => {{
+                let className = data.can_i_be_loud ? "yes" : "no";
+                let el = document.getElementById("{targetElementId}");
+                el.className = className;
+                el.innerHTML = data.response_text;
+            }})
+        }}
+        can_i_be_loud();
+    </script>
 </head>
 <body>
-    <p>{}</p>
+    <div id="{targetElementId}">
+    </div>
 </body>
-</html>", rule.get_message());
+</html>"#);
 
     HttpResponse::Ok().body(answer)
 }
 
-#[post("/t")]
-async fn timezone() -> impl Responder {
-    let answer = format!("<html><body><p>test</p></body></html>");
+fn can_i_be_loud_from_tz(timezone: String) -> CanIBeLoudResponse {
+    CanIBeLoudResponse {
+        can_i_be_loud: true,
+        response_text: "yes".to_owned(),
+        requested_timezone: timezone.to_owned(),
+        timezone_found: true,
+        calculated_datetime: "2023-10-10 19:55:55".to_owned()
+    }
+}
 
-    HttpResponse::Ok().body(answer)
+async fn cibl(tz_from_request: web::Json<TimezoneFromRequest>) -> Result<impl Responder> {
+    let response = CanIBeLoudResponse {
+        can_i_be_loud: true,
+        response_text: "yes".to_owned(),
+        requested_timezone: tz_from_request.timezone.to_owned(),
+        timezone_found: true,
+        calculated_datetime: "2023-10-10 19:55:55".to_owned()
+    };
+
+    Ok(web::Json(response))
 }
 
 #[actix_web::main]
@@ -36,7 +119,7 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
         App::new()
             .service(hello)
-            .service(timezone)
+            .route("/cibl", web::post().to(cibl))
     })
     .bind(("127.0.0.1", 8080))?
     .run()


### PR DESCRIPTION
Use JS to retrieve the user's timezone and send it to the backend.

The entire HTML, JS and CSS are hardcoded as a raw string. They should be split to their own files and served separately, either using the actix's static-files approach[^1] or by embedding them in the resulting binary[^2][^3]

[^1]: https://actix.rs/docs/static-files
[^2]: https://stackoverflow.com/a/27140747/1477072
[^3]: https://doc.rust-lang.org/std/macro.include_bytes.html