### PR TITLE
Use `or` instead of `and` to check time

### DIFF
--- a/canibeloud/src/rules/europe_london.rs
+++ b/canibeloud/src/rules/europe_london.rs
@@ -23,7 +23,7 @@ impl Rulelike for EuropeLondon {
 
         let start = now.with_hour(23).unwrap().with_minute(0).unwrap();
         let end = now.with_hour(7).unwrap().with_minute(0).unwrap();
-        if now >= start && now <= end {
+        if now >= start || now <= end {
             r_response = RuleResponse { can_i_be_loud: false, response_text: String::from("No"), secondary_text: String::from(""), ..r_response};
         }
         r_response

--- a/canibeloud/src/rules/rule.rs
+++ b/canibeloud/src/rules/rule.rs
@@ -36,7 +36,7 @@ impl Rulelike for OtherTimezone {
 
         let start = now.with_hour(23).unwrap().with_minute(0).unwrap();
         let end = now.with_hour(7).unwrap().with_minute(0).unwrap();
-        if now >= start && now <= end {
+        if now >= start || now <= end {
             r_response = RuleResponse { can_i_be_loud: false, response_text: String::from("No"), secondary_text: String::from("Use common sense"), ..r_response};
         }
         r_response


### PR DESCRIPTION
If the current time is after midnight, these conditions cannot be satisfied with `and`, because we're looking at **different days.**

For example:

`2024-01-24 01:14` is before `07:00` but is not after `23:00`