### PR TITLE
Dockerize

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,33 @@ Just clone the repo and `cargo run` to run it.
 During development, you can install `cargo-watch`[^1] and set it to
 automatically recompile and run everytime there is a change with `cargo watch -x run`
 
+### Docker
+
+#### Building
+
+To build a docker image on your current branch:
+
+    $ cd canibeloud
+    $ branch=$(git rev-parse --abbrev-ref HEAD)
+    $ docker buildx build --platform=linux/amd64 -t canibeloud:${branch} .
+
+Notice the `--platform` argument and the `TARGET_ARCHITECTURE` in the Dockerfile.
+
+The first one tells docker which version of the images to fetch from dockerhub, whereas
+the second tells rust which architecture the build is intended for.
+
+#### Running
+
+To run the image you just built:
+
+    $ docker run --rm --platform linux/amd64 -p 8080:8080 -e CAN_I_BE_LOUD_BIND_ADDR=0.0.0.0 -it canibeloud:${branch}
+
+
+The `--platform` argument here is necessary if you're on a different architecture (e.g. an
+M1 Mac) but you want to run an x86_64 image.
+
+Also the `-e CAN_I_BE_LOUD_BIND_ADDR=0.0.0.0` is required because by default the actix
+server binds on `127.0.0.1`, which won't accept any requests when running inside a container.
+
 
 [^1]: https://crates.io/crates/cargo-watch

--- a/canibeloud/.dockerignore
+++ b/canibeloud/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+
+.vscode/*
+target/*

--- a/canibeloud/Cargo.lock
+++ b/canibeloud/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "env_logger",
+ "log",
  "serde",
 ]
 

--- a/canibeloud/Cargo.toml
+++ b/canibeloud/Cargo.toml
@@ -10,4 +10,5 @@ actix-web = "4"
 chrono = "0.4.31"
 chrono-tz = "0.8.5"
 env_logger = "0.11.1"
+log = "0.4.20"
 serde = { version = "1.0", features = ["derive"] }

--- a/canibeloud/Dockerfile
+++ b/canibeloud/Dockerfile
@@ -1,0 +1,20 @@
+ARG TARGET_ARCHITECTURE=x86_64-unknown-linux-gnu
+
+FROM rust:1.75.0-slim-buster as build
+
+ARG TARGET_ARCHITECTURE
+
+# RUN apt-get update && apt-get install -y musl-tools
+RUN rustup target add ${TARGET_ARCHITECTURE}
+
+COPY . /src
+WORKDIR /src
+
+RUN cargo build --release --target=${TARGET_ARCHITECTURE}
+
+FROM ubuntu:22.04 as release
+ARG TARGET_ARCHITECTURE
+
+COPY --from=build /src/target/${TARGET_ARCHITECTURE}/release/canibeloud .
+
+CMD ["./canibeloud"]

--- a/canibeloud/src/main.rs
+++ b/canibeloud/src/main.rs
@@ -1,3 +1,5 @@
+use std::env;
+use log::info;
 mod rules;
 mod canibeloud;
 
@@ -146,14 +148,18 @@ async fn cibl(tz_from_request: web::Json<TimezoneFromRequest>) -> Result<impl Re
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    let bind_addr = env::var("CAN_I_BE_LOUD_BIND_ADDR").unwrap_or("127.0.0.1".into());
+    let port = env::var("CAN_I_BE_LOUD_PORT").unwrap_or("8080".into());
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    info!("Listening on {bind_addr}:{port}");
     HttpServer::new(|| {
         App::new()
             .service(index)
             .route("/cibl", web::post().to(cibl))
             .wrap(Logger::new(r#"%t %a "%{r}a" "%r" %s %b %Dms "%{Referer}i" "%{User-Agent}i""#))
     })
-    .bind(("127.0.0.1", 8080))?
+    .bind((bind_addr, port.parse().unwrap()))?
     .run()
     .await
 }


### PR DESCRIPTION
Add dockerfile and allow configuration from ENV vars.

Initially I wanted the `release` stage to be a `FROM scratch` image containing only the resulting binary, but this proved to be more difficult that I expected, especially because I had to cater for and align many different things:

- different architectures (ARM and non-ARM)
- different libraries (musl vs gnu) 
- different building steps which did not overlap, but still added to the confusion (docker buildx, cargo cross, rustup target) 
- as well as [some libraries](https://github.com/gyscos/zstd-rs/issues) that they would just not build for different architectures 

The main drive for pursuing `FROM scratch` in the first place was for the smaller image size. 
The image produced from this PR is 91.3MB, which is good enough for this.