### PR TITLE
Decrease red intensity for `.no` class

### DIFF
--- a/canibeloud/src/static/index.html
+++ b/canibeloud/src/static/index.html
@@ -50,7 +50,7 @@
         }
 
         .no {
-            background-color: rgb(215, 0, 21);
+            background-color:  #d4351c;
             color: #f3f2f1;
         }
 


### PR DESCRIPTION
Replace Apple's vibrant red color[^1] with a more muted version coming from gov.uk styleguide[^2]

[^1]: https://developer.apple.com/design/human-interface-guidelines/color#Specifications
[^2]: https://design-system.service.gov.uk/styles/colour/


### Before

<img width="884" alt="Screenshot 2024-02-04 at 11 20 45" src="https://github.com/sakisv/canibeloud/assets/4289633/5b5fd65d-3b50-4be2-872a-1ea7ea3ed8ff">


### After

<img width="890" alt="Screenshot 2024-02-04 at 11 21 28" src="https://github.com/sakisv/canibeloud/assets/4289633/568dbb60-2c39-4eb7-aea1-ee5713179042">
