### PR TITLE
Faster docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,17 @@ automatically recompile and run everytime there is a change with `cargo watch -x
 
 ### Docker
 
-#### Building
+#### Building and pushing the `builder` image
+
+To build the `builder` which contains precompiled versions of the dependencies:
+
+    $ cd canibeloud
+    $ docker buildx build --build-arg --platform=linux/arm64 -t sakisv/canibeloud-builder:main -f Dockerfile-builder  .
+    $ docker push sakisv/canibeloud-builder:main
+
+#### Building the app image
+
+The app image relies on the `builder` image being available on dockerhub ☝️
 
 To build a docker image on your current branch:
 
@@ -28,7 +38,9 @@ To build a docker image on your current branch:
     $ branch=$(git rev-parse --abbrev-ref HEAD)
     $ docker buildx build --platform=linux/amd64 -t canibeloud:${branch} .
 
-Notice the `--platform` argument and the `TARGET_ARCHITECTURE` in the Dockerfile.
+By default this will build an image for `linux/amd64` and the rust target will be `aarch64-unknown-linux-gnu`.
+
+These are controlled by the `--platform` argument in the command above and the `ARG TARGET_ARCHITECTURE` in the Dockerfile.
 
 The first one tells docker which version of the images to fetch from dockerhub, whereas
 the second tells rust which architecture the build is intended for.

--- a/canibeloud/.dockerignore
+++ b/canibeloud/.dockerignore
@@ -1,4 +1,6 @@
 Dockerfile
+Dockerfile-builder
+.dockerignore
 
 .vscode/*
 target/*

--- a/canibeloud/Dockerfile
+++ b/canibeloud/Dockerfile
@@ -1,4 +1,4 @@
-ARG TARGET_ARCHITECTURE=x86_64-unknown-linux-gnu
+ARG TARGET_ARCHITECTURE=aarch64-unknown-linux-gnu
 
 FROM rust:1.75.0-slim-buster as build
 

--- a/canibeloud/Dockerfile
+++ b/canibeloud/Dockerfile
@@ -1,19 +1,24 @@
 ARG TARGET_ARCHITECTURE=aarch64-unknown-linux-gnu
 
-FROM rust:1.75.0-slim-buster as build
 
+# step 1
+
+FROM sakisv/canibeloud-builder:main as build
 ARG TARGET_ARCHITECTURE
 
 RUN rustup target add ${TARGET_ARCHITECTURE}
 
-COPY . /src
-WORKDIR /src
+COPY . /code
+WORKDIR /code
 
 RUN cargo build --release --target=${TARGET_ARCHITECTURE}
+
+
+# step 2
 
 FROM ubuntu:22.04 as release
 ARG TARGET_ARCHITECTURE
 
-COPY --from=build /src/target/${TARGET_ARCHITECTURE}/release/canibeloud .
+COPY --from=build /code/target/${TARGET_ARCHITECTURE}/release/canibeloud .
 
 CMD ["./canibeloud"]

--- a/canibeloud/Dockerfile-builder
+++ b/canibeloud/Dockerfile-builder
@@ -11,4 +11,4 @@ RUN mkdir src && echo 'fn main() {println!("hello world");}' > src/main.rs
 COPY Cargo.* .
 
 RUN cargo build --release --target=${TARGET_ARCHITECTURE}
-RUN rm -rf src/main.rs
+RUN rm -rf src/ target/${TARGET_ARCHITECTURE}/release/.fingerprint/canibeloud-*

--- a/canibeloud/Dockerfile-builder
+++ b/canibeloud/Dockerfile-builder
@@ -1,4 +1,4 @@
-ARG TARGET_ARCHITECTURE=x86_64-unknown-linux-gnu
+ARG TARGET_ARCHITECTURE=aarch64-unknown-linux-gnu
 
 FROM rust:1.75.0-slim-buster
 

--- a/canibeloud/Dockerfile-builder
+++ b/canibeloud/Dockerfile-builder
@@ -7,7 +7,7 @@ ARG TARGET_ARCHITECTURE
 RUN rustup target add ${TARGET_ARCHITECTURE}
 
 WORKDIR /code
-RUN mkdir src && echo 'fn main() {}' > src/main.rs
+RUN mkdir src && echo 'fn main() {println!("hello world");}' > src/main.rs
 COPY Cargo.* .
 
 RUN cargo build --release --target=${TARGET_ARCHITECTURE}

--- a/canibeloud/Dockerfile-builder
+++ b/canibeloud/Dockerfile-builder
@@ -1,0 +1,14 @@
+ARG TARGET_ARCHITECTURE=x86_64-unknown-linux-gnu
+
+FROM rust:1.75.0-slim-buster
+
+ARG TARGET_ARCHITECTURE
+
+RUN rustup target add ${TARGET_ARCHITECTURE}
+
+WORKDIR /code
+RUN mkdir src && echo 'fn main() {}' > src/main.rs
+COPY Cargo.* .
+
+RUN cargo build --release --target=${TARGET_ARCHITECTURE}
+RUN rm -rf src/main.rs


### PR DESCRIPTION
Compiling the app on my CI took a ridiculous long time (see #23) due to a combination of slow/old hardware and too many things to compile.

This PR addresses the 2nd part, by creating a `builder` image which includes our dependencies that have been compiled on a much faster system. This means that the CI will only have to compile the app and should dramatically reduce the required time.